### PR TITLE
Update Foreman 3.18 API documentation

### DIFF
--- a/foreman/3.18/apidoc/v2/config_reports.html
+++ b/foreman/3.18/apidoc/v2/config_reports.html
@@ -520,9 +520,9 @@
 
 
   <h3>Examples</h3>
-    <pre class="prettyprint">POST /api/v2/reports
+    <pre class="prettyprint">POST /api/v2/config_reports
 {
-  &quot;report&quot;: {
+  &quot;config_report&quot;: {
     &quot;host&quot;: &quot;report.example.com&quot;,
     &quot;logs&quot;: [
       {

--- a/foreman/3.18/apidoc/v2/config_reports/create.html
+++ b/foreman/3.18/apidoc/v2/config_reports/create.html
@@ -49,9 +49,9 @@
 
 
   <h2>Examples</h2>
-    <pre class="prettyprint">POST /api/v2/reports
+    <pre class="prettyprint">POST /api/v2/config_reports
 {
-  &quot;report&quot;: {
+  &quot;config_report&quot;: {
     &quot;host&quot;: &quot;report.example.com&quot;,
     &quot;logs&quot;: [
       {


### PR DESCRIPTION
- Fixed endpoint path in examples: /api/v2/reports -> /api/v2/config_reports
- Fixed parameter name in examples: report -> config_report
